### PR TITLE
Set default SSH log path based on operating system

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"corteca/internal/configuration"
 	"corteca/internal/device"
+	"corteca/internal/platform"
 	"fmt"
 	"strings"
 
@@ -30,7 +31,7 @@ func init() {
 		return []string{"tar.gz, tar"}, cobra.ShellCompDirectiveFilterFileExt
 	})
 	rootCmd.AddCommand(execCmd)
-	execCmd.PersistentFlags().StringVar(&sshLogging, "ssh-log", "/dev/null", "Specify where SSH logs will be stored")
+	execCmd.PersistentFlags().StringVar(&sshLogging, "ssh-log", platform.DefaultSSHLog, "Specify where SSH logs will be stored")
 	execCmd.PersistentFlags().StringVar(&publishTargetName, "publish", "", "Publish application artifact to specified target")
 	execCmd.PersistentFlags().BoolVar(&skipLocalConfig, "global", false, "Affect global config & ignore any project-local configuration")
 }

--- a/internal/platform/darwin.go
+++ b/internal/platform/darwin.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 )
 
+const DefaultSSHLog = "/dev/null"
+
 func SetConfigPaths() (string, string) {
 	systemConfigRoot := filepath.Join("/", "usr", "local", "etc", "corteca")
 	userConfigRoot := filepath.Join(os.Getenv("HOME"), ".config", "corteca")

--- a/internal/platform/linux.go
+++ b/internal/platform/linux.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 )
 
+const DefaultSSHLog = "/dev/null"
+
 func SetConfigPaths() (string, string) {
 	homeDir, _ := os.UserHomeDir()
 	systemConfigRoot := filepath.Join("/", "etc", "corteca")

--- a/internal/platform/windows.go
+++ b/internal/platform/windows.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 )
 
+const DefaultSSHLog = "NUL"
+
 func SetConfigPaths() (string, string) {
 	systemConfigRoot := filepath.Join(os.Getenv("PROGRAMDATA"), "Corteca")
 	userConfigRoot := filepath.Join(os.Getenv("APPDATA"), "Corteca")


### PR DESCRIPTION
When executing `corteca exec install beacon` on Windows, the command fails when attempting to connect via SSH, displaying the following error:
`Error while connecting to device console: open /dev/null: The system cannot find the path specified.`
This happens because [this line](https://github.com/nokia/corteca-cli/blob/43f7c02fcb1cc835609b4204d687f9035610ca23/cmd/exec.go#L33) sets the default SSH log file to `/dev/null`, which does not exist on Windows.

This pull request addresses the issue by setting the default SSH log file based on the operating system. However, I’m open to feedback on whether this is the best approach.