### PR TITLE
Normalize file paths in regen file check

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -920,6 +920,6 @@ func ReadYamlInto(value interface{}, in io.Reader) error {
 }
 
 func isRegenFile(path string, info TemplateInfo) bool {
-	_, exists := info.RegenFiles[path]
+	_, exists := info.RegenFiles[filepath.ToSlash(path)]
 	return exists
 }


### PR DESCRIPTION
When executing `corteca create`  on Windows, the templates ADF.template and Dockerfile.template are not skipped as expected.
This happens because in [this line](https://github.com/nokia/corteca-cli/blob/43f7c02fcb1cc835609b4204d687f9035610ca23/internal/configuration/configuration.go#L923) the regen file is searched using a path that has not been normalized, causing issues with slash differences on Windows.
This pull request fixes the issue by applying filepath.ToSlash to normalize the path before searching.
Feedback is welcome!