### PR TITLE
Ensure slash use during corteca.yaml creation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,7 +142,7 @@ func validateAppSettings() error {
 		return fmt.Errorf("DUID has not been generated successfully")
 	}
 	if config.App.Entrypoint == "" {
-		config.App.Entrypoint = filepath.Join("/bin", config.App.Name)
+		config.App.Entrypoint = filepath.ToSlash(filepath.Join("/bin", config.App.Name))
 	}
 	return nil
 }


### PR DESCRIPTION
When executing `corteca create` on Windows, the `config.App.Entrypoint` is set to `\bin\<config.App.Name>`, causing the generated `corteca.yaml` file to be incorrect and preventing the image from working properly.
This happen because, in [this line](https://github.com/nokia/corteca-cli/blob/43f7c02fcb1cc835609b4204d687f9035610ca23/cmd/root.go#L145), the entrypoint is set using `filepath.Join` which is OS-dependent.
This pull request fixes the issue by applying `filepath.ToSlash` when setting the entrypoint. Feedback is welcome!