### PR TITLE
Add .dockerignore file to exclude build artifacts.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.cache
+.vscode/
+/dist
+.deploy.log
+nfpm.yaml
+Dockerfile


### PR DESCRIPTION
This pull request adds a `.dockerignore` file to reduce the build context size and speed up the build process with Docker.

When building the Corteca CLI using Docker, it may take some extra time transferring the build context to the Docker daemon - especially due to the size of the `dist `directory with the build artifacts.

### Performance comparison (personal scenario):
| OS | Before | After |
|--------|--------|--------|
| Windows | **~30s** to load build context (**158.8 MB**) + ~6s for `COPY . .` | **~0.4s** to load build context (**14 KB**) + ~0.6s for `COPY . .` |
| Linux (WSL) | **~9s** to load build context (**166.51 MB**) + ~12s for `COPY . .` | **~0.5s** to load build context (**9.85 KB**) + ~0.2s for `COPY . .` |

I realize there may be additional files or directories that could also be added to the `.dockerignore` list. But to keep it simple and easy to review I only added the entries from the `.gitignore`, with primary focus on excluding the `dist` folder, as it is the largest contributor to the build context size.

Feedback is welcome!