### PR TITLE
inherit ADF mounts and hooks from corteca.yaml

### DIFF
--- a/data/templates/_base/.corteca/ADF.template
+++ b/data/templates/_base/.corteca/ADF.template
@@ -19,14 +19,19 @@
     ]
   },
   "mounts": [
+    {{- range $index, $mount := .app.runtime.mounts }}
+    {{- if $index }}, {{ end }}
     {
-      "destination": "/opt",
-      "source": "/var/run/ubus-session",
+      "destination": "{{- $mount.destination }}",
+      "source": "{{- $mount.source }}",
       "options": [
-        "rbind",
-        "rw"
+        {{- range $j, $opt := $mount.options }}
+        {{- if $j }}, {{ end }}
+        "{{ $opt }}"
+        {{- end }}
       ]
     }
+    {{- end }}
   ],
   "network": {
     "type": "share"
@@ -41,5 +46,23 @@
         "period": "100"
       }
     }
+  },
+  "hooks": {
+    "prestart": [
+      {{- range $index, $path := .app.runtime.hooks.prestart }}
+      {{- if $index }}, {{ end }}
+      {
+        "path": "{{ $path.path }}"
+      }
+      {{- end }}
+    ],
+    "poststop": [
+      {{- range $index, $path := .app.runtime.hooks.poststop }}
+      {{- if $index }}, {{ end }}
+      {
+        "path": "{{ $path.path }}"
+      }
+      {{- end }}
+    ]
   }
 }


### PR DESCRIPTION
This PR adds some small changes to the default `ADF.template` which will ensure that volume mounts and container hooks specified in `corteca.yaml` are properly carried-over into the generated ADF file.