### PR TITLE
Fix PowerShell module installation path on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,8 @@ unix-completions: default-corteca-binary
 
 
 windows-completions: default-corteca-binary
-	mkdir -p $(PS1_COMPLETION_DIR)
-	$(BIN)/default-$(BINARY_NAME)-$(BUILD_ENV_GOOS)-$(BUILD_ENV_GOARCH)-$(VERSION) -r data/ completion powershell > $(PS1_COMPLETION_DIR)/$(BINARY_NAME).ps1; \
-	
+	mkdir -p $(PS1_COMPLETION_MODULE_DIR)
+	$(BIN)/default-$(BINARY_NAME)-$(BUILD_ENV_GOOS)-$(BUILD_ENV_GOARCH)-$(VERSION) -r data/ completion powershell > $(PS1_COMPLETION_MODULE_DIR)/$(BINARY_NAME_CAPITALIZED).psm1; \
 
 install: $(GOOS)-target
 
@@ -96,7 +95,9 @@ msi: PKGNAME := $(BINARY_NAME)_$(VERSION)_$(GOARCH).msi
 msi: GUID := $(shell uuidgen)
 msi: INSTALLER_XML := corteca.wxs
 msi: DEST_REL_PATH := $(shell realpath --relative-to=$(CURRDIR) $(DESTDIR))
+msi: BINARY_NAME_CAPITALIZED := $(shell echo $(BINARY_NAME) | awk '{print toupper(substr($$0,1,1)) tolower(substr($$0,2))}')
 msi: PS1_COMPLETION_DIR := ${DESTDIR}/completions
+msi: PS1_COMPLETION_MODULE_DIR := $(PS1_COMPLETION_DIR)/$(BINARY_NAME_CAPITALIZED)
 msi: $(GOOS)-target | $(PACKAGES)
 msi: windows-completions
 	mv $(DESTDIR)/opt/corteca/$(BINARY_NAME) $(DESTDIR)/opt/corteca/$(BINARY_NAME).exe


### PR DESCRIPTION
The Windows MSI installer for version 32.1.1 was placing the file `corteca.ps1` in `$HOME\Documents\PowerShell\Modules`.
However when trying to import the module to enable autocompletion functionality, PowerShell throws the following error:


```powershell
Import-Module -Name corteca
Import-Module: The specified module 'corteca' was not loaded because no valid module file was found in any module directory.
```

This PR fixes the issue by:
- Moving the file to a subfolder named `Corteca` (as [required](https://learn.microsoft.com/en-us/powershell/scripting/developer/module/how-to-write-a-powershell-script-module?view=powershell-7.5#:~:text=To%20create%20a%20script%20module%2C%20save%20a%20valid%20PowerShell%20script%20to%20a%20.psm1%20file.%20The%20script%20and%20the%20directory%20where%20it%27s%20stored%20must%20use%20the%20same%20name.%20For%20example%2C%20a%20script%20named%20MyPsScript.psm1%20is%20stored%20in%20a%20directory%20named%20MyPsScript.) for PowerShell modules)
- Renaming the file from `.ps1` to `.psm1` so that it is recognized as a valid module.

After this change, running `Import-Module -Name Corteca` works as expected and enables autocompletions.

_Could be interesting to considering adding `Import-Module -Name Corteca` to `$PROFILE` when corteca is installed or create a module manifest to enable auto-import._

Let me know if there’s anything you’d like to adjust. Thanks! 😊