### PR TITLE
Fix app settings population

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -43,6 +43,9 @@ func doExecSequence(sequencename, deviceName string) {
 	if devConfig, found := config.Devices[deviceName]; !found {
 		failOperation(fmt.Sprintf("no config for device '%s' was found", deviceName))
 	} else {
+		if !skipLocalConfig {
+			requireBuildArtifact()
+		}
 		configuration.GetCmdContext().Device.DeviceConfig = devConfig
 		configuration.GetCmdContext().Device.Name = deviceName
 		configuration.GetCmdContext().Arch = configuration.GetCmdContext().Device.Architecture


### PR DESCRIPTION
Require build artifact(s) when executing a deployment sequence, unless explicitly requested to regard only global configuration.

Fixes #23