### PR TITLE
Implement `host.name` and `host.addr` tempate variables

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,7 +29,7 @@ corteca config set`,
 }
 
 var getCmd = &cobra.Command{
-	Use:   "get key",
+	Use:   "get KEY",
 	Short: "Read a configuration value",
 	Long:  "Read a configuration value from global or application's corteca.yaml file",
 	Example: `#Read build configuration value 'outputType'
@@ -49,7 +49,7 @@ corteca config get devices.beacon`,
 }
 
 var setCmd = &cobra.Command{
-	Use:   "set key value",
+	Use:   "set KEY VALUE",
 	Short: "Set a configuration value",
 	Long:  "Set a configuration value to global or application's corteca.yaml file",
 	Example: `#Set build configuration value 'outputType'
@@ -69,7 +69,7 @@ corteca config --global set build.crossCompile.args "["--reset", "-p", "yes"]"`,
 }
 
 var addCmd = &cobra.Command{
-	Use:   "add key value",
+	Use:   "add KEY VALUE",
 	Short: "Add (append) a configuration value",
 	Long:  "Add (append) a configuration value to global or application's corteca.yaml file",
 	Example: `#Add to devices a device named 'beacon6' with its configuration fields
@@ -79,6 +79,15 @@ corteca config add devices "{beacon6: {addr: ssh://root:passwd@192.168.67.5, pas
 	Run:               func(cmd *cobra.Command, args []string) { doSetConfigValue(args[0], args[1], true) },
 }
 
+var evalCmd = &cobra.Command{
+	Use:               "eval EXPR",
+	Short:             "Evaluate a configuration value",
+	Long:              "Evaluate a configuration value based on template substitution",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: validConfigArgsFunc,
+	Run:               func(cmd *cobra.Command, args []string) { doEvalConfigValue(args[0]) },
+}
+
 func init() {
 	setCmd.PersistentFlags().BoolVar(&noRegen, "no-regen", false, "Skip regeneration of templates")
 	addCmd.PersistentFlags().BoolVar(&noRegen, "no-regen", false, "Skip regeneration of templates")
@@ -86,6 +95,7 @@ func init() {
 	configCmd.AddCommand(getCmd)
 	configCmd.AddCommand(setCmd)
 	configCmd.AddCommand(addCmd)
+	configCmd.AddCommand(evalCmd)
 	rootCmd.AddCommand(configCmd)
 }
 
@@ -125,6 +135,16 @@ func doSetConfigValue(key, value string, append bool) {
 			doRegenTemplates(projectRoot, "")
 		}
 	}
+}
+
+func doEvalConfigValue(expr string) {
+	if len(projectRoot) > 0 {
+		requireProjectContext()
+	}
+	field := configuration.T(expr)
+	enc := yaml.NewEncoder(os.Stdout)
+	enc.SetIndent(configuration.YamlIndentation)
+	enc.Encode(field.String())
 }
 
 func validConfigArgsFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -81,8 +81,8 @@ corteca config add devices "{beacon6: {addr: ssh://root:passwd@192.168.67.5, pas
 
 var evalCmd = &cobra.Command{
 	Use:               "eval EXPR",
-	Short:             "Evaluate a configuration value",
-	Long:              "Evaluate a configuration value based on template substitution",
+	Short:             "Evaluate a configuration expression",
+	Long:              "Evaluate a configuration expression potentially containing template substitutions",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: validConfigArgsFunc,
 	Run:               func(cmd *cobra.Command, args []string) { doEvalConfigValue(args[0]) },

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
+	github.com/vishvananda/netlink v1.3.1 // indirect
+	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,10 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
 github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
 github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=
+github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
+github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
+github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
+github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/xinsnake/go-http-digest-auth-client v0.6.0 h1:nrYFWDrB2F7VwYlNravXZS0nOtg9axlATH3Jns55/F0=
 github.com/xinsnake/go-http-digest-auth-client v0.6.0/go.mod h1:QK1t1v7ylyGb363vGWu+6Irh7gyFj+N7+UZzM0L6g8I=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
@@ -155,7 +159,9 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220906165534-d0df966e6959/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -27,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
+	"github.com/vishvananda/netlink"
 	"gopkg.in/yaml.v3"
 )
 
@@ -44,6 +46,7 @@ func init() {
 	regexKeyValue = regexp.MustCompile(`^([[:word:]]+)=(.*)$`)
 	regexDollarExpr = regexp.MustCompile(`\${\s*(?:\"([^"]*)\":)?(\.?(?:\w*)(?:\.\w*)*)(?:\:(\S))?(?:\:(\S))?\s*}`)
 	populateEnvVars()
+	ResetContext()
 }
 
 // Top level object of application configuration settings
@@ -224,6 +227,19 @@ type CmdContext struct {
 	Build    *BuildSettings    `yaml:"build,omitempty"`
 	Artifact string            `yaml:"artifact,omitempty"`
 	Env      map[string]string `yaml:"env,omitempty"`
+	Host     struct {
+		Name string `yaml:"name"`
+		Addr string `yaml:"addr"`
+	} `yaml:"host"`
+}
+
+func getHostInfo() (string, string) {
+	var hostName, hostAddr string
+	hostName, _ = os.Hostname()
+	if routes, err := netlink.RouteGet(net.ParseIP("1.1.1.1")); err == nil {
+		hostAddr = routes[0].Src.String()
+	}
+	return hostName, hostAddr
 }
 
 func ResetContext() {
@@ -231,6 +247,7 @@ func ResetContext() {
 		App:   &AppSettings{},
 		Build: &BuildSettings{},
 	}
+	commandContext.Host.Name, commandContext.Host.Addr = getHostInfo()
 }
 
 func GetCmdContext() *CmdContext {


### PR DESCRIPTION
Also provide a new `corteca config eval` command to test configuration templates.