### PR TITLE
Fix docker build: msix for Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM builder-image AS build-stage
 WORKDIR /app
 COPY . .
 
-RUN make msi GOARCH=amd64 && \
+RUN make msix GOARCH=amd64 && \
     make deb GOARCH=amd64 && \
     make rpm GOARCH=amd64 && \
     make osx GOARCH=amd64 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.25
 
 FROM golang:${GO_VERSION}-alpine AS builder-image
 RUN apk update && apk add \
@@ -13,7 +13,7 @@ RUN apk update && apk add \
     zip \
     git \
     gettext
-RUN go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.40.0
+RUN go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.46.0
 
 FROM builder-image AS go-test-coverage-stage
 WORKDIR /test-coverage


### PR DESCRIPTION
The Windows packages target should be msix. This is a fix for issue #29.