### PR TITLE
Fix prerequisites in the documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,14 @@ FROM builder-image AS build-stage
 WORKDIR /app
 COPY . .
 
-RUN make msix GOARCH=amd64 && \
-    make deb GOARCH=amd64 && \
-    make rpm GOARCH=amd64 && \
-    make osx GOARCH=amd64 && \
-    make deb GOARCH=arm64 && \
-    make rpm GOARCH=arm64 && \
-    make osx GOARCH=arm64
+ARG ARCH="amd64 arm64"
+ARG PACKAGE="msix deb rpm osx"
+RUN for arch in ${ARCH}; do \
+      for pkg in ${PACKAGE}; do \
+        [ $pkg != msix -o $arch == amd64 ] || continue; \
+        make $pkg GOARCH=$arch || exit 1; \
+      done; \
+    done
 
 FROM scratch AS build-artifacts
 COPY --from=build-stage /app/dist /

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ $ make rpm
 
 #### Installing nFPM
 
-If an sppropriate package is not available for your platform, you can install nFPM with:
+If an appropriate package is not available for your platform, you can install nFPM with:
 
-```
-go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.46.0
+```bash
+$ go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.46.0
 ```
 
 ## Getting Started
@@ -213,8 +213,8 @@ The `corteca config` command can be used to inspect or modify any value
 without editing YAML by hand:
 
 ```bash
-corteca config get publish          # show all publish targets
-corteca config set app.version 1.1  # update a value
+$ corteca config get publish          # show all publish targets
+$ corteca config set app.version 1.1  # update a value
 ```
 
 For a full reference of every configuration key, their types, defaults, and
@@ -238,6 +238,6 @@ For a broader overview of all commands, flags, and usage patterns see
 Every command also accepts `--help` for inline usage information:
 
 ```bash
-corteca --help
-corteca build --help
+$ corteca --help
+$ corteca build --help
 ```

--- a/README.md
+++ b/README.md
@@ -83,21 +83,46 @@ can be targeted by name when running `corteca exec`.
 
 ## Build
 
-Clone the repository and run:
+### Building Locally
+
+To build locally, you need to have a Go toolchain installed. Clone the repository and run:
 
 ```bash
 $ make
 ```
 
-The compiled binary is placed in the `dist/` directory.
+The compiled binary is placed in the `dist/` directory. You can also build packages for your specific platform. The available `make` targets are `deb`, `rpm`, `osx` and `msix`:
+
+```bash
+$ make rpm
+```
 
 ### Build using Docker
 
-If you do not have a local Go toolchain, you can build entirely inside Docker
-(BuildKit is required):
+If you do not have a local Go toolchain, you can build entirely inside Docker (BuildKit is required). The following command builds all supported packages:
 
 ```bash
 $ docker build --output ./dist .
+```
+
+#### Selecting the Packages to Build
+
+By default, packages are created for all architectures (`arm64` and `amd64`). You can select the architectires to build for by setting the `ARCH` build-time variable to the space-separated list of architectures to build for. For example, to only build packages for the `amd64` architecture run:
+
+```bash
+$ docker build --build-arg ARCH="amd64" --output ./dist .
+```
+
+The package types created by default are `deb`, `rpm`, `osx` and `msix`. To only build selected package types, set the `PACKAGE` build-time variable to the space-separated list of package types to build. The following command only builds `deb` and `rpm` packages on all architectures:
+
+```bash
+$ docker build --build-arg PACKAGE="deb rpm" --output ./dist .
+```
+
+By setting both the `ARCH` and `PACKAGE` build-time variables, you can further limit the build scope to specific packages. For example, to only build the `deb` package for the `amd64` architecture, run:
+
+```bash
+$ docker build --build-arg ARCH="amd64" --build-arg PACKAGE="deb" --output ./dist .
 ```
 
 #### Installing Docker BuildKit
@@ -111,8 +136,6 @@ $ sudo apt-get install docker-buildx-plugin
 Then either prefix each `docker build` invocation with `DOCKER_BUILDKIT=1`, or
 follow the [official instructions](https://docs.docker.com/build/buildkit/#getting-started)
 to enable it globally.
-
-> For the full build guide see [doc/BUILD.md](doc/BUILD.md).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ can be targeted by name when running `corteca exec`.
 
 | Requirement | Version  | Notes                                          |
 | ----------- | -------- | ---------------------------------------------- |
-| Go          | ≥ 1.21   | Required to build from source                  |
+| Go          | ≥ 1.25   | Required to build from source                  |
+| nFPM        | ≥ 2.46   | Required to build from source                  |
 | Docker      | ≥ 23.0   | Required to build application container images |
 | Docker BuildKit | ≥ 0.11 | Required for `docker build --output`         |
 | make        | any      | Used to drive the build and install targets    |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ can be targeted by name when running `corteca exec`.
 | Requirement | Version  | Notes                                          |
 | ----------- | -------- | ---------------------------------------------- |
 | Go          | ≥ 1.25   | Required to build from source                  |
-| nFPM        | ≥ 2.46   | Required to build from source                  |
+| nFPM        | ≥ 2.46   | Required to build packages locally             |
 | Docker      | ≥ 23.0   | Required to build application container images |
 | Docker BuildKit | ≥ 0.11 | Required for `docker build --output`         |
 | make        | any      | Used to drive the build and install targets    |
@@ -142,11 +142,19 @@ $ DESTDIR=~/.local/share make install
 
 ### Install with package manager
 
-If you are using debian/ubuntu or redhat-based distributions, you can create a relevant package and let your package manager handle installation. E.g. for ubuntu:
+If you are using debian/ubuntu or redhat-based distributions, you can create a relevant package and let your package manager handle installation (nFPM is required). E.g. for Ubuntu:
 
 ```bash
 $ make deb
 $ make rpm
+```
+
+#### Installing nFPM
+
+If an sppropriate package is not available for your platform, you can install nFPM with:
+
+```
+go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.46.0
 ```
 
 ## Getting Started


### PR DESCRIPTION
Fix the prerequisites to reflect the current requirements for Go and add a requirement for nFPM for local builds:
* nFPM at least 2.46.0 is required to build msix packages
* Go at least version 1.25 is required by nFPM 2.46.0