### PR TITLE
Add link flag to strip the Corteca CLI binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION := $(shell git describe --tags)
-BUILD_FLAGS := -x -v -ldflags "-X corteca/cmd.appVersion=$(VERSION)"
+BUILD_FLAGS := -x -v -ldflags "-X corteca/cmd.appVersion=$(VERSION) -s"
 HOSTOS ?= $(shell go env GOOS)
 HOSTARCH ?= $(shell go env GOARCH)
 DESTOS ?= $(HOSTOS)


### PR DESCRIPTION
Append '-s' to the options for the link go tool. This option will omit the symbol table, debug information, and implicitly the DWARF symbol table from the resulting binary.