### PR TITLE
Honor the build.crossCompile.enabled value

### DIFF
--- a/internal/builder/docker.go
+++ b/internal/builder/docker.go
@@ -24,6 +24,9 @@ func execDocker(args ...string) error {
 }
 
 func enableCrossCompilation(crossCompileSettings configuration.CrossCompileConfig) error {
+	if !crossCompileSettings.Enabled {
+		return nil
+	}
 	args := []string{"run", "--rm", "--privileged", crossCompileSettings.Image}
 	args = append(args, crossCompileSettings.Args...)
 


### PR DESCRIPTION
The configuration value build.crossCompile.enabled is always assumed to be true, and the image to enable it is always run regardless. This change will skip this step if enabled is set to false. Since the default value is true, the default behavior remains the same.

This is a fix for issue #16.